### PR TITLE
Correctly use keys and values to build query string

### DIFF
--- a/src/OElite.Restme.Utils/QueryUtils.cs
+++ b/src/OElite.Restme.Utils/QueryUtils.cs
@@ -33,9 +33,9 @@ namespace OElite
             if (values?.Count > 0)
             {
                 int index = 0;
-                foreach (var k in values)
+                foreach (var k in values.Keys)
                 {
-                    result = index == 0 ? $"{k}={WebUtility.UrlEncode(values[k.ToString()])}" : $"&{k}={WebUtility.UrlEncode(values[k.ToString()])}";
+                    result = index == 0 ? $"{k}={WebUtility.UrlEncode(values[k])}" : $"&{k}={WebUtility.UrlEncode(values[k])}";
                 }
             }
             if (includeQuestionMark)


### PR DESCRIPTION
This is a fix for Issue 21: "When including a query string, KeyNotFoundException is thrown"
Here is a link to the issue: https://github.com/oelite/RESTme/issues/21

Sorry, but I wasn't able to associate this pull request with the issue.
